### PR TITLE
Modernize language and update for 2027

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,32 +1,26 @@
 # What is WPILib?
 
-The WPI Robotics Library (WPILib) is the standard software library provided for teams to write code for their FIRST&reg; Robotics Competition (FRC&reg;) robots.  A [software library](https://en.wikipedia.org/wiki/Library_(computing)) is a collection of code that can be imported into and used by other software.  WPILib contains a set of useful classes and subroutines for interfacing with various parts of the FRC control system (such as sensors, motor controllers, and the driver station), as well as an assortment of other utility functions.
+WPILib is the standard software library and toolsuite provided for teams to write, test, and debug code for their *FIRST*&reg; Robotics Competition and *FIRST*&reg; Tech Challenge robots.  A [software library](https://en.wikipedia.org/wiki/Library_(computing)) is a collection of code that can be imported into and used by other software.  WPILib contains a set of useful classes and subroutines for interfacing with various parts of the *FIRST*&reg; control system (such as sensors, motor controllers, and the driver station), as well as an assortment of other utility functions.
 
 ## Supported languages
 
-There are three versions of WPILib, one for each of the three officially-supported text-based languages: WPILibJ for Java, and WPILibC for C++, and RobotPy for Python.  A considerable effort is made to maintain feature-parity between these languages - library features are not added unless they can be reasonably supported for both Java and C++ (with the C++ able to be wrapped by pybind for Python), and when possible the class and method names are kept identical or highly-similar.  Java, C++, and Python were chosen for the officially-supported languages due to their appropriate level-of-abstraction and ubiquity in both industry and high-school computer science classes.
+There are three officially-supported text-based languages for WPILib: Java, C++, and Python.  A considerable effort is made to maintain feature-parity between these languages, but WPILib may make features available to specific languages in cases where the feature represents a significant benefit to teams but cannot be implemented across all languages.  When possible, class and method names are kept identical or highly-similar.  Java, C++, and Python were chosen for the officially-supported languages due to their appropriate level-of-abstraction and broad use in both industry and education.
 
-In general, C++ offers better high-end performance, at the cost of increased user effort (memory must be handled manually, and the C++ compiler does not do much to ensure user code will not crash at runtime).  Java and Python offer lesser performance, but much greater convenience.  Python users should take care to test their program to ensure that typos and other issues don't cause robot crashes, as Python is interpreted. New/inexperienced users are encouraged to use Java. 
+In general, C++ offers better high-end performance, at the cost of increased user effort (memory must be handled manually, and the C++ compiler does not do much to ensure user code will not crash at runtime).  Java and Python offer lesser performance, but much greater convenience.  Python users should take care to test their program to ensure that typos and other issues don't cause robot crashes, as Python is interpreted. New/inexperienced users are encouraged to use Java or Python.
 
 ## Source code and documentation
 
 The primary documentation for WPILib is the [FIRST Robotics Competition Control System Documentation](https://docs.wpilib.org/).
 
-WPILib is an open-source library - the C++ and Java source code is in the [allwpilib](https://github.com/wpilibsuite/allwpilib) mono-repo and python source code is in the [mostrobotpy](https://github.com/robotpy/mostrobotpy) mono-repo.  The Java and C++ source code can be found in the WPILibJ and WPILibC source directories:
-
- - [Java source code](https://github.com/wpilibsuite/allwpilib/tree/main/wpilibj/src/main/java/edu/wpi/first/wpilibj)
-
- - [C++ source code](https://github.com/wpilibsuite/allwpilib/tree/main/wpilibc/src/main/native/cpp)
-
- - [Python source code](https://github.com/robotpy/mostrobotpy)
-
-While users are strongly encouraged to read the source code to resolve detailed questions about library functionality, more-concise documentation can be found on the official documentation pages for WPILibJ and WPILibC and RobotPy:
+Detailed API documentation can be found on the official documentation pages for each language:
 
  - [Java documentation](https://javadocs.wpilib.org)
 
  - [C++ documentation](https://cppdocs.wpilib.org)
 
  - [Python documentation](https://robotpy.readthedocs.io/projects/robotpy/en/latest/)
+
+WPILib is an open-source library - the majority of the library source code is in the [allwpilib](https://github.com/wpilibsuite/allwpilib) mono-repo.   Python source code is in the [mostrobotpy](https://github.com/robotpy/mostrobotpy) mono-repo.  Various other tooling and infrastructure code is in other repositories under the [wpilibsuite](https://github.com/wpilibsuite) organization on GitHub.
 
 ## Installation
 


### PR DESCRIPTION
- adjust language to be cross-platform between FRC and FTC
- Remove distinction of "3 versions of wpilib" as well as the wpilibc and wpilibj naming
- update feature-parity policy
- remove "While users are strongly encouraged to read the source code to resolve detailed questions about library functionality" and move source code info below api docs
- remove links to wpilibc and wpilibj source - the library is more than wpilibc/j and is in multiple subprojects


There is still one reference to "FIRST Robotics Competition Control System Documentation", but this is currently the title of the docs and can be updated later ("FIRST Control System Documentation"?)